### PR TITLE
Make dask-friendly

### DIFF
--- a/suitcase/germ/handlers.py
+++ b/suitcase/germ/handlers.py
@@ -3,7 +3,14 @@ import h5py
 from .conversions import payload2event, DATA_TYPEMAP
 
 
-class BinaryGeRMHandler(HandlerBase):
+class BinaryGeRMHandler():
+    '''
+        This is the handler for datasets using the runs 2018 onwards.
+
+        This will take the filename of the binary data.
+        Upon call, this will return a column by name.
+    '''
+
     specs = {'BinaryGeRM'}
 
     def __init__(self, fpath, chunksize=None):
@@ -62,7 +69,7 @@ class BinaryGeRMHandler(HandlerBase):
         self._file.close()
 
 
-class GeRMHandler(HandlerBase):
+class GeRMHandler():
     specs = {'GeRM'}
 
     def __init__(self, fpath):

--- a/suitcase/germ/handlers.py
+++ b/suitcase/germ/handlers.py
@@ -3,27 +3,42 @@ import h5py
 from .conversions import payload2event, DATA_TYPEMAP
 
 
-class BinaryGeRMHandler():
-    '''
-        This is the handler for datasets using the runs 2018 onwards.
-
-        This will take the filename of the binary data.
-        Upon call, this will return a column by name.
-    '''
+class BinaryGeRMHandler(HandlerBase):
     specs = {'BinaryGeRM'}
 
-    def __init__(self, fpath):
-        # TODO : don't save the raw data (here for debugging)
-        raw_data = np.fromfile(fpath, dtype='>u4')
-        # TODO : when simulated data comes in, verify this is correct
-        # endianness and correct for it, don't just raise error
+    def __init__(self, fpath, chunksize=None):
+        ''' Binary GeRM handler.
+
+        Parameters
+        ----------
+        chunksize : int, optional
+            if specified, this turns result into a dask array
+            This array is a lazy loaded array. To obtain the results
+            one must call the .compute() method.
+            This is useful when the data is too large to fit in memory.
+
+        Notes
+        -----
+        When using chunksize, use functools.partial, and functools.wraps
+        Example ::
+            from functools import partial, wraps
+            bgermdask = wraps(BinaryGeRMHandler)(partial(BinaryGeRMHandler,
+                                                         chunksize=100000))
+            fhandler_init = bgermdask(filename)
+            res = fhandler_init['germ_ts']
+            # etc...
+        '''
+        raw_data = np.memmap(fpath, dtype='>u4')
+
+        # verify the data
         first_word = raw_data[0]
+        last_word = raw_data[-1]
+
         if first_word != 0xfeedface:
             msg = "Error, first 32 bit word not 0xfeedface"
             msg += f"\n Got {first_word:#x} instead"
             raise ValueError(msg)
 
-        last_word = raw_data[-1]
         if last_word != 0xdecafbad:
             msg = "Error, first 32 bit word not 0xdecafbad"
             msg += f"\n Got {last_word:#x} instead"
@@ -31,20 +46,23 @@ class BinaryGeRMHandler():
 
         # remove first and last region
         raw_data = raw_data[2:-2]
+
+        # now the raw_data is a dask array, lazy loaded
+        if chunksize is not None:
+            raw_data = da.from_array(raw_data, chunks=chunksize)
+
+        # this will work with lazy or non-lazy modes
         self.data = payload2event(raw_data)
 
     def __call__(self, column):
+        # NOTE: can return a lazy array
         return self.data[DATA_TYPEMAP[column]]
 
     def close(self):
         self._file.close()
 
 
-class GeRMHandler():
-    '''
-        This is the legacy handler used for data sets before 2018.
-        It is not used after 2018.
-    '''
+class GeRMHandler(HandlerBase):
     specs = {'GeRM'}
 
     def __init__(self, fpath):


### PR DESCRIPTION
If you specify a `chunksize`, now returns dask arrays.

This extends the file handler to work with dask:

Usage:
```py3
from functools import wraps, partial

BinaryGeRMHandlerDask = wraps(BinaryGeRMHandler)(partial(BinaryGeRMHandler,
                                                             chunksize=1000000))
db.reg.register_handler("BinaryGeRM", BinaryGeRMDask)
```